### PR TITLE
Move ffmpeg dir to /config

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -37,6 +37,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "19.03.22:", desc: "Add config for ffmpeg path to prevent permission issue." }
   - { date: "17.05.21:", desc: "Deprecating the env vars `USER`, `PASSWORD` and `USE_JSON` as mStream v5 requires the use of `config.json`." }
   - { date: "23.01.21:", desc: "Rebasing to alpine 3.13." }
   - { date: "01.06.20:", desc: "Rebasing to alpine 3.12." }

--- a/root/defaults/config.json
+++ b/root/defaults/config.json
@@ -17,5 +17,11 @@
   },
   "folders": {
     "library": { "root": "/music" }
+  },
+  "transcode": {
+    "enabled": "false",
+    "ffmpegDirectory": "/config/bin",
+    "defaultCodec": "opus",
+    "defaultBitrate": "128k"
   }
 }

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -2,7 +2,7 @@
 
 # make folders
 mkdir -p \
-    /config/{album-art,db,logs}
+    /config/{album-art,db,logs,bin}
 
 # copy config.json if doesn't exist
 [[ ! -e /config/config.json ]] && \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-mstream/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Add transcode config in config.json to address https://github.com/IrosTheBeggar/mStream/issues/359. As lsio image run as user but the permission of `/opt/mstream/bin` still as root. Update config.json to use `/config/bin/` as it preventing permission issue also promote ffmpeg persistence.
Refer from [mstream config docs](https://github.com/IrosTheBeggar/mStream/blob/master/docs/json_config.md)
```
 "transcode": {
    "enabled": false,
    "ffmpegDirectory": "/path/to/ffmpeg-dir",
    "defaultCodec": "opus",
    "defaultBitrate": "128k"
  },
```
Adapted to lsio image
```
 "transcode": {
    "enabled": false,
    "ffmpegDirectory": "/config/bin",
    "defaultCodec": "opus",
    "defaultBitrate": "128k"
  },
```

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Preventing user permissiong error and promote ffmpeg persistence.

## How Has This Been Tested?
Local custom config by adding the part stated above.


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://github.com/IrosTheBeggar/mStream/issues/359
https://github.com/IrosTheBeggar/mStream/blob/master/docs/json_config.md