### PR TITLE
Rebase to Alpine 3.24, use distro onnxruntime for the discovery embedding runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-alpine:3.23
+FROM ghcr.io/linuxserver/baseimage-alpine:3.24
 
 # set version label
 ARG BUILD_DATE
@@ -15,7 +15,9 @@ RUN \
   echo "**** install runtime packages ****" && \
   apk add --no-cache --upgrade \
     ffmpeg \
+    gcompat \
     nodejs \
+    onnxruntime \
     openssl \
     yt-dlp && \
   apk add --no-cache --upgrade --virtual=build-dependencies \
@@ -36,6 +38,16 @@ RUN \
   cd /app/mstream && \
   chown -R abc:abc ./ && \
   su -s /bin/sh abc -c 'HOME=/tmp npm install --omit=dev' && \
+  echo "**** use distro onnxruntime for the discovery embedding runtime ****" && \
+  if [ -d /app/mstream/node_modules/onnxruntime-node/bin/napi-v6/linux/x64 ]; then \
+    rm -f \
+      /app/mstream/node_modules/onnxruntime-node/bin/napi-v6/linux/x64/libonnxruntime.so.1 \
+      /app/mstream/node_modules/onnxruntime-node/bin/napi-v6/linux/x64/libonnxruntime_providers_cuda.so \
+      /app/mstream/node_modules/onnxruntime-node/bin/napi-v6/linux/x64/libonnxruntime_providers_tensorrt.so && \
+    ln -s \
+      /usr/lib/libonnxruntime.so.1 \
+      /app/mstream/node_modules/onnxruntime-node/bin/napi-v6/linux/x64/libonnxruntime.so.1; \
+  fi && \
   npm link && \
   chmod +x /app/mstream/bin/rust-parser/* && \
   printf "Linuxserver.io version: ${VERSION}\nBuild-date: ${BUILD_DATE}" > /build_version && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.23
+FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.24
 
 # set version label
 ARG BUILD_DATE
@@ -15,7 +15,9 @@ RUN \
   echo "**** install runtime packages ****" && \
   apk add --no-cache --upgrade \
     ffmpeg \
+    gcompat \
     nodejs \
+    onnxruntime \
     openssl \
     yt-dlp && \
   apk add --no-cache --upgrade --virtual=build-dependencies \
@@ -36,6 +38,16 @@ RUN \
   cd /app/mstream && \
   chown -R abc:abc ./ && \
   su -s /bin/sh abc -c 'HOME=/tmp npm install --omit=dev' && \
+  echo "**** use distro onnxruntime for the discovery embedding runtime ****" && \
+  if [ -d /app/mstream/node_modules/onnxruntime-node/bin/napi-v6/linux/arm64 ]; then \
+    rm -f \
+      /app/mstream/node_modules/onnxruntime-node/bin/napi-v6/linux/arm64/libonnxruntime.so.1 \
+      /app/mstream/node_modules/onnxruntime-node/bin/napi-v6/linux/arm64/libonnxruntime_providers_cuda.so \
+      /app/mstream/node_modules/onnxruntime-node/bin/napi-v6/linux/arm64/libonnxruntime_providers_tensorrt.so && \
+    ln -s \
+      /usr/lib/libonnxruntime.so.1 \
+      /app/mstream/node_modules/onnxruntime-node/bin/napi-v6/linux/arm64/libonnxruntime.so.1; \
+  fi && \
   npm link && \
   chmod +x /app/mstream/bin/rust-parser/* && \
   printf "Linuxserver.io version: ${VERSION}\nBuild-date: ${BUILD_DATE}" > /build_version && \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -72,6 +72,7 @@ init_diagram: |
   "mstream:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "08.07.26:", desc: "Rebase to Alpine 3.24. Use the distro onnxruntime so the discovery/recommendation features work on musl."}
   - {date: "24.04.26:", desc: "Make waveform data persistent."}
   - {date: "20.04.26:", desc: "Fix perms on rust binaries."}
   - {date: "07.04.26:", desc: "Add ffmpeg and yt-dlp."}


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-mstream/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

Closes #35.

- Rebase to Alpine 3.24 (both Dockerfiles).
- Add `gcompat` and `onnxruntime` to the runtime packages.
- After `npm install`, replace the bundled glibc `libonnxruntime.so.1` inside `onnxruntime-node` with a symlink to the distro's musl build, and remove the bundled CUDA/TensorRT provider libraries (~316 MB) that CPU inference never loads.
- Changelog entry in readme-vars.yml.

## Benefits of this PR and context:

mStream ≥6.16 ships a discovery/recommendation engine whose embedding model runs on `onnxruntime-node`. That npm package bundles **glibc-only** binaries, so on this image the worker dies at import (`Error loading shared library ld-linux-x86-64.so.2`) and the feature can never build its data (#35).

`gcompat` alone is not enough — the bundled runtime references fortified glibc symbols (`__vsnprintf_chk`, `__memcpy_chk`, …) that the shim doesn't implement. But Alpine 3.24's community repo now packages a **native musl onnxruntime 1.24.4**, the same 1.24 line the npm binding targets. With the distro runtime symlinked in, the only glibc code left is the npm package's thin 384 KB N-API binding, which gcompat handles fine.

Net effect: the recommendation features work, and the image *shrinks* by ~350 MB (the deleted CUDA/TensorRT libs outweigh the added packages).

The `if [ -d … ]` guard keeps the build working even if a future mStream release drops the optional `onnxruntime-node` dependency. If mStream ever moves to a newer onnxruntime line before Alpine does, mStream detects the failed load (as of IrosTheBeggar/mStream#718, in the next release), logs one clear error, and disables the embedding pass — the image itself is never broken by drift.

## How Has This Been Tested?

- Built this Dockerfile (x86_64) locally and ran it with `collectDiscoveryData` enabled against a small music library: the embedding pass completed real inferences — `Discovery-embedding pass complete: 6 embedded, 0 error(s)` — and the discovery DB contains 1280-d embeddings + genre predictions.
- The recipe was first validated clean-room in a plain `alpine:3.24` container with the real model (18 MB EffNet ONNX): full inference passes with the system runtime + gcompat; fails without.
- Confirmed the `onnxruntime` apk exists for **aarch64** at 3.24 as well (`onnxruntime-1.24.4-r1` via qemu); the arm64 image itself was not run here and deserves a smoke in your CI.

## Source / References:

- Issue: https://github.com/linuxserver/docker-mstream/issues/35
- Alpine package: https://pkgs.alpinelinux.org/package/v3.24/community/x86_64/onnxruntime
- mStream-side graceful degradation + docs: https://github.com/IrosTheBeggar/mStream/pull/718
